### PR TITLE
Enable unittest discovery & Create README for tests

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,9 @@
+# Tests
+## Run Tests
+To run tests, run `python3 -m unittest discover -s tests` in the root folder. 
+
+## Create Tests
+We use `unittest` to write out tests. To enable discovery, ensure the following requirements are met:
+- Ensure that all tests files start with the word `test`. 
+- Must include `__init__.py` in every test folders.
+- The test class needs to inherit from `unittest.TestCase`.

--- a/tests/artifact_storage/test_basic.py
+++ b/tests/artifact_storage/test_basic.py
@@ -1,9 +1,10 @@
 import tempfile
+import unittest
 
 from aimrecords import Storage
 
 
-class TestMulitpleArtifacts(object):
+class TestMulitpleArtifacts(unittest.TestCase):
     def test_simple_int(self):
         len = 1000
 

--- a/tests/record_storage/test_basic.py
+++ b/tests/record_storage/test_basic.py
@@ -1,11 +1,12 @@
 import os
 import tempfile
+import unittest
 
 from aimrecords.record_storage.reader import Reader
 from aimrecords.record_storage.writer import Writer
 
 
-class TestBasicStuff(object):
+class TestBasicStuff(unittest.TestCase):
     def test_simple_int(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             path = os.path.join(temp_dir, 'loss')

--- a/tests/record_storage/test_compression.py
+++ b/tests/record_storage/test_compression.py
@@ -1,11 +1,12 @@
 import os
 import tempfile
+import unittest
 
 from aimrecords.record_storage.reader import Reader
 from aimrecords.record_storage.writer import Writer
 
 
-class TestBucketCompression(object):
+class TestBucketCompression(unittest.TestCase):
     def test_gzip_compression(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             path = os.path.join(temp_dir, 'loss')

--- a/tests/record_storage/test_modes.py
+++ b/tests/record_storage/test_modes.py
@@ -1,11 +1,12 @@
 import os
 import tempfile
+import unittest
 
 from aimrecords.record_storage.reader import Reader
 from aimrecords.record_storage.writer import Writer
 
 
-class TestWriteAppendModes(object):
+class TestWriteAppendModes(unittest.TestCase):
     def test_append_mode_binary(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             path = os.path.join(temp_dir, 'loss')

--- a/tests/record_storage/test_modification_time.py
+++ b/tests/record_storage/test_modification_time.py
@@ -1,11 +1,12 @@
 import os
 import tempfile
+import unittest
 
 from aimrecords.record_storage.writer import Writer
 from aimrecords.record_storage.reader import Reader
 
 
-class TestModTime(object):
+class TestModTime(unittest.TestCase):
     def test_modification_time(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             path = os.path.join(temp_dir, 'loss')

--- a/tests/record_storage/test_read_write.py
+++ b/tests/record_storage/test_read_write.py
@@ -1,11 +1,12 @@
 import os
 import tempfile
+import unittest
 
 from aimrecords.record_storage.reader import Reader
 from aimrecords.record_storage.writer import Writer
 
 
-class TestReadWrite(object):
+class TestReadWrite(unittest.TestCase):
     def test_dirty_read(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             path = os.path.join(temp_dir, 'loss')


### PR DESCRIPTION
- Ensure that all test files start with the word `test`.
- The test class needs to be inherited from `unittest.TestCase`.
- Create README providing guidelines for how to write tests.

Now all tests can be run by `python3 -m unittest discover -s tests`